### PR TITLE
Remove usage of `base-bytes`

### DIFF
--- a/stringext.opam
+++ b/stringext.opam
@@ -9,7 +9,6 @@ depends: [
   "dune" {build & >= "1.0"}
   "ounit2" {with-test}
   "qtest" {with-test & >= "2.2"}
-  "base-bytes"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
It is not necessary since `bytes` ships with the compiler.