### PR TITLE
Add examples for Stringext (OCaml Examples Project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,8 @@ val take : string -> int -> string
     from [s] starting from [pos] and up to [len] *)
 val trim_left_sub : string -> pos:int -> len:int -> chars:string -> string
 ```
+
+## Examples
+
+See the directory `examples`. This is a separate dune workspace, so install
+Stringext first. 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,17 @@
+# stringext
+
+This example is for the stringext library
+
+https://opam.ocaml.org/packages/stringext
+
+# Source file
+
+`bin/main.ml`
+
+# Building and running
+
+`dune exec bin/main.exe`
+
+# Cleaning up
+
+`dune clean`

--- a/examples/bin/dune
+++ b/examples/bin/dune
@@ -1,0 +1,3 @@
+(executable
+ (name main)
+ (libraries stringext))

--- a/examples/bin/main.ml
+++ b/examples/bin/main.ml
@@ -1,0 +1,57 @@
+(* Exercise each function in Stringext. *)
+
+let go () =
+  Printf.printf "After the space: %S\n"
+    (Stringext.string_after "Mozart" 3);
+  Printf.printf "Like Str.quote (but without Str): %S\n"
+    (Stringext.quote "Some specials *+*+");
+  Printf.printf "Split makes %i splits\n"
+    (List.length (Stringext.split "Mary had a little lamb" ~on:' '));
+  Printf.printf "Full split makes %i splits\n"
+    (List.length (Stringext.full_split "Mary had a little lamb" ~on:' '));
+  Printf.printf "Trimming: %S\n"
+    (Stringext.trim_left "    <--- to here");
+  Printf.printf "split_trim_left: ";
+    let strings = Stringext.split_trim_left "+one +two -three" ~on:" " ~trim:"+-" in
+      List.iter (Printf.printf "%S ") strings;
+      Printf.printf "\n";
+  Printf.printf "'a' with of_char is: %S\n"
+    (Stringext.of_char 'a');
+  Printf.printf "of_list makes: %S\n"
+    (Stringext.of_list (Stringext.to_list "chimpanzee"));
+  Printf.printf "of_array and to_array makes: %S\n"
+    (Stringext.of_array (Stringext.to_array "marzipan"));
+  Printf.printf "find_from: %s\n"
+    begin match Stringext.find_from ~start:5 "again and again" ~pattern:"again" with
+    | None -> ""
+    | Some x -> string_of_int x
+    end;
+  Printf.printf "replace_all: %S\n"
+    (Stringext.replace_all "Again. And again. And again." ~pattern:"." ~with_:"!!");
+  Printf.printf "replace_all_assoc: %S\n"
+    (Stringext.replace_all_assoc
+       "Again. And again. And again" [(".", "!!"); ("And", "Yet")]);
+  begin match Stringext.cut "cut<-->here" ~on:"<-->" with
+  | Some (l, r) -> Printf.printf "cut: %S %S\n" l r
+  | None -> ()
+  end;
+  begin match Stringext.rcut "cut<-->here" ~on:"<-->" with
+  | Some (l, r) -> Printf.printf "rcut: %S %S\n" l r
+  | None -> ()
+  end;
+  Printf.printf "chop_prefix: %S\n"
+    begin match Stringext.chop_prefix "- list item" ~prefix:"- " with
+    | None -> "" (* returns none if prefix not found *)
+    | Some x -> x
+    end;
+  Printf.printf "drop: %S\n"
+    (Stringext.drop "-------->" 5);
+  Printf.printf "take: %S\n"
+    (Stringext.take "-------->" 5);
+  Printf.printf "trim_left_sub: %S\n"
+    (Stringext.trim_left_sub "-23-56+89+" ~pos:0 ~len:10 ~chars:"+-")
+
+let () =
+  match Sys.argv with
+  | [|_|] -> go ()
+  | _ -> Printf.eprintf "stringext example: unknown command line\n"

--- a/examples/dune-project
+++ b/examples/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(name stringext_example)

--- a/examples/dune-workspace
+++ b/examples/dune-workspace
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(env (dev (flags :standard -warn-error -A)))


### PR DESCRIPTION
Hello!

This pull request adds some examples to Stringext. This is part of a pilot programme funded by the OCaml Software Foundation.

Many OCaml libraries have no examples, or perfunctory examples only. This makes
it difficult to get started with a library, particularly if it has an elaborate
interface. A working example, no matter how small, can help a newcomer get
started quickly. One day, it would be nice to have an example for every opam package.

For now, examples begin in the OCaml Nursery, here: https://github.com/johnwhitington/ocaml-nursery  (you can read in the README there about the principles behind these examples.) Then, if package authors agree, they are promoted to upstream source. The hope is that this will mean they are more likely to be kept up to date with the library.

The examples are included in a separate directory, within a separate Dune workspace. And so they are intended to be used after installation of the library.

As well as considering accepting this pull request, please give any comments you have on this programme.